### PR TITLE
Set static green equalisation to fix red x

### DIFF
--- a/src/labthings_picamera2/recalibrate_utils.py
+++ b/src/labthings_picamera2/recalibrate_utils.py
@@ -431,6 +431,26 @@ def lst_is_static(tuning: dict) -> bool:
     return alsc["n_iter"] == 0
 
 
+def set_static_geq(
+    tuning: dict
+) -> None:
+    """Update the `rpi.geq` section of a camera tuning dict to always use green
+    equalisation that averages the green pixels in the red and blue rows.
+
+    `tuning` will be updated in-place to set the geq offest to the maximum. This means
+    the brightness will always be below the threshold where averaging is used.
+    """
+
+    geq = Picamera2.find_tuning_algo(tuning, "rpi.geq")
+    geq["offset"] = 65535  # max out offset to disable the adaptive green equalisation
+
+
+def _geq_is_static(tuning: dict) -> bool:
+    """Whether the green equalisation is set to static"""
+    geq = Picamera2.find_tuning_algo(tuning, "rpi.geq")
+    return alsc["offset"] == 65535
+
+
 def index_of_algorithm(algorithms: list[dict], algorithm: str):
     """Find the index of an algorithm's section in the tuning file"""
     for i, a in enumerate(algorithms):
@@ -483,6 +503,7 @@ if __name__ == "__main__":
         tuning = load_default_tuning(cam)
     f = np.ones((12, 16))
     set_static_lst(tuning, f, f, f)
+    set_static_geq(tuning)
     with Picamera2(tuning=tuning) as cam:
         cam.start_preview()
         time.sleep(3)


### PR DESCRIPTION
Note this isn't tested on any hardware yet

I think this should set the `rpi.geq` parameter `offset` to 65535. I have only run my routine in one place. Can you check I have run in the correct place @rwb27

[This comment](https://github.com/raspberrypi/picamera2/issues/1160#issuecomment-2476721903) in an issue thread on picamera2 explains the fix