### PR TITLE
Pre dev1 fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "labthings-picamera2"
-version = "0.0.1"
+version = "0.0.1-dev1"
 authors = [
   { name="Richard Bowman", email="richard.bowman@cantab.net" },
 ]

--- a/src/labthings_picamera2/recalibrate_utils.py
+++ b/src/labthings_picamera2/recalibrate_utils.py
@@ -455,17 +455,19 @@ def lst_is_static(tuning: dict) -> bool:
 
 
 def set_static_geq(
-    tuning: dict
+    tuning: dict,
+    offset: int = 65535,
 ) -> None:
     """Update the `rpi.geq` section of a camera tuning dict to always use green
     equalisation that averages the green pixels in the red and blue rows.
 
-    `tuning` will be updated in-place to set the geq offest to the maximum. This means
+    `tuning` will be updated in-place to set the geq offest to the given value.
+    The default 65535 is the maximum allowed value. This means
     the brightness will always be below the threshold where averaging is used.
     """
 
     geq = Picamera2.find_tuning_algo(tuning, "rpi.geq")
-    geq["offset"] = 65535  # max out offset to disable the adaptive green equalisation
+    geq["offset"] = offset  # max out offset to disable the adaptive green equalisation
 
 
 def _geq_is_static(tuning: dict) -> bool:

--- a/src/labthings_picamera2/recalibrate_utils.py
+++ b/src/labthings_picamera2/recalibrate_utils.py
@@ -3,8 +3,7 @@ Functions to set up a Raspberry Pi Camera v2 for scientific use
 
 This module provides slower, simpler functions to set the
 gain, exposure, and white balance of a Raspberry Pi camera, using
-`picamerax` (a fork of `picamera`) to get as-manual-as-possible
-control over the camera.  It's mostly used by the OpenFlexure
+the `picamera2` Python library.  It's mostly used by the OpenFlexure
 Microscope, though it deliberately has no hard dependencies on
 said software, so that it's useful on its own.
 
@@ -22,7 +21,7 @@ pipeline, is to use raw images.  This is quite slow, but very
 reliable.  The three steps above can be accomplished by:
 
 ```
-picamera = picamerax.PiCamera()
+picamera = picamera2.Picamera2()
 
 adjust_shutter_and_gain_from_raw(picamera)
 adjust_white_balance_from_raw(picamera)

--- a/src/labthings_picamera2/thing.py
+++ b/src/labthings_picamera2/thing.py
@@ -295,15 +295,6 @@ class StreamingPiCamera2(Thing):
                 print("gc.collect()")
                 gc.collect()
                 Picamera2._cm = picamera2.picamera2.CameraManager()
-                m = libcamera.CameraManager.singleton()
-                print("libcamera.CameraManager.singleton().restart()")
-                try:
-                    m.restart()
-                except AttributeError:
-                    logging.error(
-                        "libcamera.CameraManager nas no attribute `restart`, you probably "
-                        "need to install the patched fork of `pylibcamera`"
-                    )
             print("[re]creating Picamera2 object")
             self._picamera = picamera2.Picamera2(
                 camera_num=self.camera_num,

--- a/src/labthings_picamera2/thing.py
+++ b/src/labthings_picamera2/thing.py
@@ -686,6 +686,21 @@ class StreamingPiCamera2(Thing):
         with self.picamera(pause_stream=True) as cam:
             recalibrate_utils.set_static_ccm(self.tuning, c)
             self.initialise_picamera()
+    
+    @thing_action
+    def set_static_green_equalisation(self, offset: int = 65535):
+        """Set the green equalisation to a static value.
+        
+        Green equalisation avoids the debayering algorithm becoming confused
+        by the two green channels having different values, which is a problem
+        when the chief ray angle isn't what the sensor was designed for, and
+        that's the case in e.g. a microscope using camera module v2.
+        
+        A value of 0 here does nothing, a value of 65535 is maximum correction.
+        """
+        with self.picamera(pause_stream=True) as cam:
+            recalibrate_utils.set_static_green_equalisation(cam, offset)
+            self.initialise_picamera()
 
     @thing_action
     def full_auto_calibrate(self):

--- a/src/labthings_picamera2/thing.py
+++ b/src/labthings_picamera2/thing.py
@@ -699,7 +699,7 @@ class StreamingPiCamera2(Thing):
         A value of 0 here does nothing, a value of 65535 is maximum correction.
         """
         with self.picamera(pause_stream=True) as cam:
-            recalibrate_utils.set_static_green_equalisation(cam, offset)
+            recalibrate_utils.set_static_geq(self.tuning, offset)
             self.initialise_picamera()
 
     @thing_action


### PR DESCRIPTION
This fixes a couple of things:

* I've removed `picamerax` from the docstring: it's no longer a dependency
* I've removed spurious errors about restarting the camera manager: this is no longer needed since the upstream fix for #3 
* I've fixed a typo in the green equalisation `action`.
* I've bumped the dev version for tagging

Fixes #10