### PR TITLE
Less logging.info

### DIFF
--- a/src/labthings_picamera2/thing.py
+++ b/src/labthings_picamera2/thing.py
@@ -520,14 +520,14 @@ class StreamingPiCamera2(Thing):
         stream (either "main" for the preview stream, or "lores" for the low
         resolution preview). No metadata is returned.
         """
-        logging.info(
+        logging.debug(
             f"StreamingPiCamera2.grab_jpeg(stream_name={stream_name}) starting"
         )
         stream = (
             self.lores_mjpeg_stream if stream_name == "lores" else self.mjpeg_stream
         )
         frame = portal.call(stream.grab_frame)
-        logging.info(
+        logging.debug(
             f"StreamingPiCamera2.grab_jpeg(stream_name={stream_name}) got frame"
         )
         return JPEGBlob.from_bytes(frame)


### PR DESCRIPTION
Current behaviour, ofm log is dominated by 

`[2024-12-03 15:49:00,239] [INFO] StreamingPiCamera2.grab_jpeg(stream_name=main) starting`

`[2024-12-03 15:49:00,268] [INFO] StreamingPiCamera2.grab_jpeg(stream_name=main) got frame`

Dropping these messages to debug makes the log more readable