### PR TITLE
Switch mode and return high res array

### DIFF
--- a/src/labthings_picamera2/thing.py
+++ b/src/labthings_picamera2/thing.py
@@ -694,6 +694,13 @@ class StreamingPiCamera2(Thing):
             return cam.camera_configuration()
 
     @thing_action
+    def highres_mode_and_capture_array(self):
+        with self.picamera(pause_stream=True) as cam:
+            cam.configure(cam.create_still_configuration())
+            cam.start()
+            return cam.capture_array("main")
+
+    @thing_action
     def capture_jpeg(
         self,
         metadata_getter: GetThingStates,


### PR DESCRIPTION
A new function to pause the stream, change to a high res configuration, capture a high res array.

Allows us to capture full resolution arrays instead of blobs