### PR TITLE
Optional wait parameters on captures

### DIFF
--- a/src/labthings_picamera2/thing.py
+++ b/src/labthings_picamera2/thing.py
@@ -528,7 +528,7 @@ class StreamingPiCamera2(Thing):
     def capture_array(
         self,
         stream_name: Literal["main", "lores", "raw"] = "main",
-        wait: float = None,
+        wait: Optional[float] = 0.9,
     ) -> ArrayModel:
         """Acquire one image from the camera and return as an array
 
@@ -537,7 +537,9 @@ class StreamingPiCamera2(Thing):
         binary image formats will be added in due course.
 
         stream_name: (Optional) The PiCamera2 stream to use, should be one of ["main", "lores", "raw"]. Default = "main"
-        wait: (Optional, float) Set a timeout in seconds. A TimeoutError is raised if this time is exceeded during capture. Default = None
+        wait: (Optional, float) Set a timeout in seconds.
+        A TimeoutError is raised if this time is exceeded during capture.
+        Default = 0.9s, lower than the 1s timeout default in picamera yaml settings
         """
         with self.picamera() as cam:
             return cam.capture_array(stream_name, wait = wait)
@@ -548,7 +550,7 @@ class StreamingPiCamera2(Thing):
         states_getter: GetThingStates,
         get_states: bool=True,
         get_processing_inputs: bool=True,
-        wait: float=None,
+        wait: Optional[float] = 0.9,
     ) -> RawImageModel:
         """Capture a raw image
         
@@ -556,7 +558,9 @@ class StreamingPiCamera2(Thing):
         as soon as an image has been captured. The output format is not intended
         to be useful, except as input to `raw_to_png`. 
 
-        wait: (Optional, float) Set a timeout in seconds. A TimeoutError is raised if this time is exceeded during capture. Default = None
+        wait: (Optional, float) Set a timeout in seconds.
+        A TimeoutError is raised if this time is exceeded during capture.
+        Default = 0.9s, lower than the 1s timeout default in picamera yaml settings
 
         When used via the HTTP interface, this function returns the data as a
         `Blob` object, meaning it can be passed to another action without
@@ -705,7 +709,7 @@ class StreamingPiCamera2(Thing):
         self,
         metadata_getter: GetThingStates,
         resolution: Literal["lores", "main", "full"] = "main",
-        wait: float = None,
+        wait: Optional[float] = 0.9,
     ) -> JPEGBlob:
         """Acquire one image from the camera as a JPEG
 
@@ -720,7 +724,8 @@ class StreamingPiCamera2(Thing):
         resolution image.
 
         wait: (Optional, float) Set a timeout in seconds.
-        A TimeoutError is raised if this time is exceeded during capture. Default = None
+        A TimeoutError is raised if this time is exceeded during capture.
+        Default = 0.9s, lower than the 1s timeout default in picamera yaml settings
 
         Note that this always uses the image processing pipeline - to
         bypass this, you must use a raw capture.


### PR DESCRIPTION
Remove unused import, and add wait parameters to captures. Default to None, so behaviour won't be changed